### PR TITLE
Binder: remove texlive from apt packages

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -6,10 +6,3 @@ gcc-7
 g++-7
 curl
 git
-# LaTeX
-texlive-base
-texlive-latex-base
-texlive-latex-extra
-texlive-fonts-recommended
-texlive-pstricks
-texlive-extra-utils


### PR DESCRIPTION
Make binder builds slightly faster.